### PR TITLE
scrollmagicのエラーを解決

### DIFF
--- a/components/Card.vue
+++ b/components/Card.vue
@@ -28,6 +28,7 @@ export default {
         triggerElement: '.animation-trigger1',
         triggerHook: 'onEnter',
         offset: 100,
+        duration: 500,
         reverse: false
       })
       .setTween('.animation-target1', {


### PR DESCRIPTION
# 概要
scrollmagicでwarningになってるので解決した。
Cardコンポーネントが連続で表示されるのが原因っぽい...?
https://github.com/janpaepke/ScrollMagic/wiki/WARNING:-tween-was-overwritten-by-another

![aecbd40622a1aa12e7575bca0c643604](https://user-images.githubusercontent.com/30612104/75426956-fd668480-5988-11ea-960d-51c8483f8015.jpg)


# 変更内容
 - Cardコンポーネントのシーンに`duration`を追加した