### PR TITLE
:+1: fontawsomeを軽くした

### DIFF
--- a/components/ArticleNews.vue
+++ b/components/ArticleNews.vue
@@ -10,7 +10,7 @@
       </h3>
       <time class="article__time">{{ date }}</time>
       <div @click="pullDownToggle()" :class="{ 'is-open': isOpen }" class="article-pullbutton">
-        <font-awesome-icon icon="angle-down" />
+        <fa-icon icon="angle-down"></fa-icon>
       </div>
     </section>
     <transition @enter="start" @after-enter="end" @before-leave="start" @after-leave="end" name="pulldown">

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -66,7 +66,8 @@ export default {
   ** Global CSS
   */
   css: [
-    'ress'// Node.js モジュールをロードする
+    'ress', // Node.js モジュールをロードする
+    '@fortawesome/fontawesome-svg-core/styles.css'
   ],
   /*
   ** Plugins to load before mounting the App
@@ -75,7 +76,8 @@ export default {
     { src: '~plugins/contentful' },
     { src: '~plugins/vue-lazyload', ssr: false },
     { src: '~plugins/vue-easy-lightbox', mode: 'client' },
-    { src: '~plugins/vue-scrollmagic', ssr: false }
+    { src: '~plugins/vue-scrollmagic', ssr: false },
+    { src: '~plugins/font-awesome', ssr: false }
   ],
   /*
   ** Nuxt.js dev-modules
@@ -93,7 +95,6 @@ export default {
   */
   modules: [
     '@nuxtjs/style-resources',
-    'nuxt-fontawesome',
     '@nuxtjs/dotenv',
     '@nuxtjs/markdownit'
   ],
@@ -102,17 +103,6 @@ export default {
       '~/assets/scss/variables.scss',
       '~/assets/scss/mixin.scss',
       '~/assets/scss/common.scss'
-    ]
-  },
-  /*
-  ** FontAwesome
-  */
-  fontawesome: {
-    imports: [
-      {
-        set: '@fortawesome/free-solid-svg-icons',
-        icons: ['fas']
-      }
     ]
   },
   /*

--- a/plugins/font-awesome.js
+++ b/plugins/font-awesome.js
@@ -1,0 +1,10 @@
+import Vue from 'vue'
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import { faAngleDown } from '@fortawesome/free-solid-svg-icons'
+
+library.add(faAngleDown)
+
+Vue.component('fa-icon', FontAwesomeIcon)
+
+Vue.config.productionTip = false


### PR DESCRIPTION
# 概要
fontawesomeを軽くした

↓変更前
<img width="1285" alt="3f46052a535afe1b7388444a16593d40" src="https://user-images.githubusercontent.com/30612104/75522151-9d391680-5a4c-11ea-9ef0-5dd6d09060c1.png">


# 変更内容
 - 必要なアイコンのみ出力できるようpluginを追加
 - nuxt-configにplugin追加

# 参考
https://qiita.com/yujiteshima/items/189105ba1512080410fb#fontawesome%E3%81%AF%E4%BD%BF%E3%81%86%E3%82%A2%E3%82%A4%E3%82%B3%E3%83%B3%E3%81%A0%E3%81%91%E8%AA%AD%E3%81%BF%E8%BE%BC%E3%82%80%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B
